### PR TITLE
Allow building images on NFS-mounted clones

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -80,6 +80,7 @@ endif
 DOCKER_RUN := docker run --rm=true --privileged \
     -v $(DOCKER_BUILDER_MOUNT) \
     -w $(DOCKER_BUILDER_WORKDIR) \
+    --tmpfs /fsroot:exec,dev \
     -e "http_proxy=$(http_proxy)" \
     -e "https_proxy=$(https_proxy)" \
     -i$(if $(TERM),t,)

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -33,7 +33,7 @@ DOCKER_VERSION=5:18.09.2~3-0~debian-stretch
 LINUX_KERNEL_VERSION=4.9.0-9-2
 
 ## Working directory to prepare the file system
-FILESYSTEM_ROOT=./fsroot
+FILESYSTEM_ROOT=/fsroot
 PLATFORM_DIR=platform
 ## Hostname for the linux image
 HOSTNAME=sonic
@@ -56,9 +56,8 @@ DEFAULT_USERINFO="Default admin user,,,"
 
 ## Prepare the file system directory
 if [[ -d $FILESYSTEM_ROOT ]]; then
-    sudo rm -rf $FILESYSTEM_ROOT || die "Failed to clean chroot directory"
+    sudo chown $(id -nu):$(id -ng) $FILESYSTEM_ROOT || die "Failed to own chroot directory"
 fi
-mkdir -p $FILESYSTEM_ROOT
 mkdir -p $FILESYSTEM_ROOT/$PLATFORM_DIR
 mkdir -p $FILESYSTEM_ROOT/$PLATFORM_DIR/x86_64-grub
 touch $FILESYSTEM_ROOT/$PLATFORM_DIR/firsttime
@@ -408,8 +407,7 @@ fi
 
 ## Organization specific extensions such as Configuration & Scripts for features like AAA, ZTP...
 if [ "${enable_organization_extensions}" = "y" ]; then
-   if [ -f files/build_templates/organization_extensions.sh ]; then
-      sudo chmod 755 files/build_templates/organization_extensions.sh
+   if [ -x files/build_templates/organization_extensions.sh ]; then
       ./files/build_templates/organization_extensions.sh -f $FILESYSTEM_ROOT -h $HOSTNAME
    fi
 fi
@@ -447,16 +445,19 @@ sudo umount $FILESYSTEM_ROOT/proc || true
 sudo mkdir $FILESYSTEM_ROOT/host
 
 ## Compress most file system into squashfs file
-sudo rm -f $ONIE_INSTALLER_PAYLOAD $FILESYSTEM_SQUASHFS
+rm -f $ONIE_INSTALLER_PAYLOAD $FILESYSTEM_SQUASHFS
 ## Output the file system total size for diag purpose
 ## Note: -x to skip directories on different file systems, such as /proc
 sudo du -hsx $FILESYSTEM_ROOT
 sudo mkdir -p $FILESYSTEM_ROOT/var/lib/docker
-sudo mksquashfs $FILESYSTEM_ROOT $FILESYSTEM_SQUASHFS -e boot -e var/lib/docker -e $PLATFORM_DIR
+sudo mksquashfs $FILESYSTEM_ROOT /tmp/$FILESYSTEM_SQUASHFS -e boot -e var/lib/docker -e $PLATFORM_DIR
+cp /tmp/$FILESYSTEM_SQUASHFS $FILESYSTEM_SQUASHFS
 
 ## Compress docker files
-pushd $FILESYSTEM_ROOT && sudo tar czf $OLDPWD/$FILESYSTEM_DOCKERFS -C var/lib/docker .; popd
+pushd $FILESYSTEM_ROOT && sudo tar czf /tmp/$FILESYSTEM_DOCKERFS -C var/lib/docker .; popd
+cp /tmp/$FILESYSTEM_DOCKERFS $FILESYSTEM_DOCKERFS
 
 ## Compress together with /boot, /var/lib/docker and $PLATFORM_DIR as an installer payload zip file
-pushd $FILESYSTEM_ROOT && sudo zip $OLDPWD/$ONIE_INSTALLER_PAYLOAD -r boot/ $PLATFORM_DIR/; popd
-sudo zip -g $ONIE_INSTALLER_PAYLOAD $FILESYSTEM_SQUASHFS $FILESYSTEM_DOCKERFS
+pushd $FILESYSTEM_ROOT && sudo zip /tmp/$ONIE_INSTALLER_PAYLOAD -r boot/ $PLATFORM_DIR/; popd
+sudo zip -g /tmp/$ONIE_INSTALLER_PAYLOAD $FILESYSTEM_SQUASHFS $FILESYSTEM_DOCKERFS
+cp /tmp/$ONIE_INSTALLER_PAYLOAD $ONIE_INSTALLER_PAYLOAD


### PR DESCRIPTION
Prior to this change, `build_debian.sh` would generate a Debian filesystem in `./fsroot`. This needs root permissions, and one of the tests that is performed is whether the user can create a character special file in the filesystem (using mknod).

On most NFS deployments, `root` is the least privileged user, and cannot run mknod. Also, attempting to run commands like rm or mv as root would fail due to permission errors, since the root user gets mapped to an unprivileged user like `nobody`.

This commit changes the location of the Debian filesystem to `/fsroot`, which is a tmpfs mount within the slave Docker. The default squashfs, docker tarball and zip files are also created within /tmp, before being copied back to /sonic as the regular user.

The side effect of this change is that the contents of `/fsroot` are no longer available once the slave container exits, however they are available within the squashfs image.